### PR TITLE
Manage dependencies with Glide and build by make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ Temporary Items
 .apdisk
 
 /vendor
+/bin
+/pq2gorm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+NAME := pq2gorm
+SRC := $(shell find . -type f -name "*.go")
+LDFLAGS := -ldflags="-s -w"
+
+GLIDE := $(shell command -v glide 2> /dev/null)
+
+.DEFAULT_GOAL := bin/$(NAME)
+
+bin/$(NAME): deps $(SRC)
+	go build $(LDFLAGS) -o bin/$(NAME)
+
+.PHONY: clean
+clean:
+	rm -rf bin/*
+	rm -rf vendor/*
+
+.PHONY: deps
+deps: glide
+	glide install
+
+.PHONY: glide
+glide:
+ifndef GLIDE
+	curl https://glide.sh/get | sh
+endif
+
+.PHONY: install
+install:
+	go install $(LDFLAGS)
+
+.PHONY: update-deps
+update-deps: glide
+	glide update

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ After installing required version of Go, you can build and install `pq2gorm` by
 ```bash
 $ go get -d -u github.com/wantedly/pq2gorm
 $ cd $GOPATH/src/github.com/wantedly/pq2gorm
-$ go build
+$ make
+$ make install
 ```
 
-`go build` generates a binary file `pq2gorm`.
+`make` generates a binary into `bin/pq2gorm`.
+`make install` put it to `$GOPATH/bin`.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ $ make install
 Run `pq2gorm` with Connection URI of a PostgresSQL database.
 Connection URI is necessary for running.
 
-### Usage:
+### Usage
 
 ```bash
-$ pq2gorm                                                                                                                                   
+$ pq2gorm
 Usage: Generate gorm model structs from PostgreSQL database schema.
   -d string
     	Set output path (default "./")

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,10 @@
+hash: 7e724c4d8c4a6fd8ede8d4edd755fcb3483404f86cb1d6c5596039906d6ecfe6
+updated: 2016-09-05T16:08:56.757679012+09:00
+imports:
+- name: github.com/gedex/inflector
+  version: 91797f1712fd58f224781be1080b8613d096187e
+- name: github.com/lib/pq
+  version: 50761b0867bd1d9d069276790bcd4a3bccf2324a
+  subpackages:
+  - oid
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/wantedly/pq2gorm
+import:
+- package: github.com/gedex/inflector
+- package: github.com/lib/pq


### PR DESCRIPTION
## WHY

There is no way to fix the revisions of dependent libraries now. 
## WHAT

Introduce [Glide](https://github.com/Masterminds/glide) to manage dependencies. In addition, create Makefile to fetch dependencies and build binary in a integrated way.
