### PR TITLE
Convert 'url' and 'id' correctly

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -65,12 +65,8 @@ func gormColName(s string) string {
 	ss := strings.Split(s, "_")
 
 	for i, word := range ss {
-		if word == "id" || word == "uid" {
+		if word == "id" || word == "uid" || word == "url" {
 			word = strings.ToUpper(word)
-		}
-
-		if strings.Contains(word, "url") {
-			word = strings.Replace(word, "url", "URL", -1)
 		}
 
 		ss[i] = strings.Title(word)

--- a/generate.go
+++ b/generate.go
@@ -65,8 +65,8 @@ func gormColName(s string) string {
 	ss := strings.Split(s, "_")
 
 	for i, word := range ss {
-		if strings.Contains(word, "id") {
-			word = strings.Replace(word, "id", "ID", -1)
+		if word == "id" || word == "uid" {
+			word = strings.ToUpper(word)
 		}
 
 		if strings.Contains(word, "url") {

--- a/generate_test.go
+++ b/generate_test.go
@@ -21,3 +21,24 @@ func TestGormTableName(t *testing.T) {
 		}
 	}
 }
+
+func TestGormColName(t *testing.T) {
+	var testdata = []struct {
+		in  string
+		out string
+	}{
+		{"description", "Description"},
+		{"user_id", "UserID"},
+		{"facebook_uid", "FacebookUID"},
+		{"candidacy", "Candidacy"},
+		{"video_id", "VideoID"},
+	}
+
+	for _, td := range testdata {
+		s := gormColName(td.in)
+
+		if s != td.out {
+			t.Fatalf("Field name does not match. expect: %s, actual: %s", td.out, s)
+		}
+	}
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -32,6 +32,8 @@ func TestGormColName(t *testing.T) {
 		{"facebook_uid", "FacebookUID"},
 		{"candidacy", "Candidacy"},
 		{"video_id", "VideoID"},
+		{"image_url", "ImageURL"},
+		{"curl_name", "CurlName"},
 	}
 
 	for _, td := range testdata {


### PR DESCRIPTION
## WHY

Currently `pq2gorm` converts `url` and `id` in field name to upper case. However, they are converted even if they are appeared in the top/middle/bottom of word (e.g. `candidacy` -> `CandIDacy`).
## WHAT

Convert `url`, `id`, `uid` to upper case if they exist as independent word.
