### PR TITLE
Convert date type to *time.Time type

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -88,7 +88,7 @@ func gormDataType(s string) string {
 		return "string"
 	case "boolean":
 		return "bool"
-	case "timestamp with time zone":
+	case "timestamp with time zone", "timestamp without time zone":
 		return "time.Time"
 	case "date":
 		return "*time.Time"

--- a/generate.go
+++ b/generate.go
@@ -90,6 +90,8 @@ func gormDataType(s string) string {
 		return "bool"
 	case "timestamp with time zone":
 		return "time.Time"
+	case "date":
+		return "*time.Time"
 	default:
 		return s
 	}

--- a/postgres.go
+++ b/postgres.go
@@ -76,17 +76,17 @@ func genModel(tableName string, outPath string, db *sql.DB) error {
 			needTimePackage = true
 
 			if isNullable == "YES" {
-				dataType = "*time.Time"
+				fieldType = "*time.Time"
 			} else {
-				dataType = "time.Time"
+				fieldType = "time.Time"
 			}
 		}
 
-		if dataType == "double precision" {
-			dataType = "float32"
+		if fieldType == "double precision" {
+			fieldType = "float32"
 		}
 
-		m := gormColName(columnName) + " " + dataType + " `" + json + "`\n"
+		m := gormColName(columnName) + " " + fieldType + " `" + json + "`\n"
 		gormStr += m
 
 		isInfered, infColName := inferORM(columnName)

--- a/postgres.go
+++ b/postgres.go
@@ -86,7 +86,7 @@ func genModel(tableName string, outPath string, db *sql.DB) error {
 			dataType = "float32"
 		}
 
-		m := gormColName(columnName) + " " + gormDataType(dataType) + " `" + json + "`\n"
+		m := gormColName(columnName) + " " + dataType + " `" + json + "`\n"
 		gormStr += m
 
 		isInfered, infColName := inferORM(columnName)

--- a/postgres.go
+++ b/postgres.go
@@ -70,8 +70,9 @@ func genModel(tableName string, outPath string, db *sql.DB) error {
 		}
 
 		json := genJSON(columnName, columnDefault, primaryKeys)
+		fieldType := gormDataType(dataType)
 
-		if dataType == "timestamp with time zone" || dataType == "timestamp without time zone" {
+		if fieldType == "time.Time" || fieldType == "*time.Time" {
 			needTimePackage = true
 
 			if isNullable == "YES" {

--- a/testdata/models/preference.go
+++ b/testdata/models/preference.go
@@ -10,6 +10,7 @@ type Preference struct {
 	UpdatedAt          *time.Time `json:"updated_at"`
 	Locale             string     `json:"locale" sql:"DEFAULT:'ja'::character varying"`
 	DeletedAt          *time.Time `json:"deleted_at"`
+	Birthday           *time.Time `json:"birthday"`
 	EmailSubscriptions string     `json:"email_subscriptions"`
 	Searchable         bool       `json:"searchable" sql:"DEFAULT:true"`
 }

--- a/testdata/testdata.sql
+++ b/testdata/testdata.sql
@@ -30,6 +30,7 @@ CREATE TABLE preferences (
     updated_at timestamp without time zone,
     locale character varying(255) DEFAULT 'ja'::character varying,
     deleted_at timestamp without time zone,
+    birthday date,
     email_subscriptions text,
     searchable boolean DEFAULT true NOT NULL
 );


### PR DESCRIPTION
## WHY

`date` type is primitive type in PostgreSQL, so it should be converted to appropriate Go type.
## WHAT

Convert `date` type to `*time.Time` type
